### PR TITLE
updated concerts.js to pull Nashville instead of Los Angeles

### DIFF
--- a/src/scripts/concerts.js
+++ b/src/scripts/concerts.js
@@ -1,6 +1,6 @@
 const concertData = {
     getConcerts() {
-        return fetch("https://app.ticketmaster.com/discovery/v2/events.json?classificationName=music&dmaId=324&apikey=lXF5cl6UEBDo2U4Mdnab2ATtQajczyPi"
+        return fetch("https://app.ticketmaster.com/discovery/v2/events.json?classificationName=music&dmaId=343&apikey=lXF5cl6UEBDo2U4Mdnab2ATtQajczyPi"
 )
 .then(results => results.json())
 .then(post => console.log(post));


### PR DESCRIPTION
Switched API URL to pull Nashville instead of Los Angeles. Review and make sure results pull Nashville events.